### PR TITLE
Mostly minor syntax fixes, or updates

### DIFF
--- a/manuscript/10.md
+++ b/manuscript/10.md
@@ -4,23 +4,23 @@ Here's the code - spot the problem!
 
 ```
 do {
-   get-aduser -filter * | select SamAccountName | ForEach-Object {
+   get-aduser -filter * | select-object -Property SamAccountName | ForEach-Object {
    
    if ($_.SamAccountName -eq $username) {
-   $username = $firstname+($lastname.Substring(0,$i))
+       $username = $firstname+($lastname.Substring(0,$i))
    
-   $i++
-   write-host $username
+       $i++
+       write-host -object $username
    }
    else {
-   $usernameexists = $false
+       $usernameexists = $false
    
    }
   }
 }
 until ($usernameexists = $false)
 
-Write-Host "Username is $username" -ForegroundColor Green
+Write-Host -object "Username is $username" -ForegroundColor Green
 ```
 
 ## Spoiler!!

--- a/manuscript/11.md
+++ b/manuscript/11.md
@@ -3,9 +3,9 @@
 Try to solve this one without running the code. But, it's okay to look at help files, if you want. Because this one is a long, single line, I'm going to kind of arbitrarily break it up to make it easier to read.
 
 ```
-Start-Process -FilePath "C:\BootStrap\$($Using:MSIFile.Name)" 
- -ArgumentList "/passive /norestart" 
- -Wait 
+Start-Process -FilePath "C:\BootStrap\$($Using:MSIFile.Name)" `
+ -ArgumentList "/passive /norestart"                          `
+ -Wait                                                        `
  -PassThru 
  ```
 

--- a/manuscript/12.md
+++ b/manuscript/12.md
@@ -22,14 +22,14 @@ Write "pony"
 Of course, `Write` is just an alias to `Write-Output`, which means it's functionally the same as:
 
 ```
-Write-Output "pony"
+Write-Output -InputObject "pony"
 ```
 
 _Functionally_ the same. In fact, these three examples have different actual performance:
 
 * `"pony"` .512ms
 * `Write "pony"` 31.37ms
-* `Write-Output "pony"` 7.137ms
+* `Write-Output -InputObject "pony"` 7.137ms
 
 The use of the alias taking longer kind of makes sense, since PowerShell has to look up the alias first. But it surprises a lot of folks to learn that _using `Write-Output` actually takes longer_ than just letting it happen "by default." Obviously, the numbers will differ from system to system based on system load, but the relative differences are what's interesting.
 

--- a/manuscript/13.md
+++ b/manuscript/13.md
@@ -46,8 +46,8 @@ Now look, that's a lot to read, and it's not especially well-formatted. So let's
 
 1. We use `-All`, and cannot use any other parameter. 
 2. We use `-CustomerId`, and do not use any other parameter.
-3. Use use `-CustomerId` and also use `-Name`.
-4. Use use `-CustomerId` and also use `-Id`. 
+3. We use `-CustomerId` and also use `-Name`.
+4. We use `-CustomerId` and also use `-Id`. 
 
 That right there is a tricky set of requirements. Parameter set #1 is easy, but #2-4 create a problem. You see, in #2, we want only `-CustomerId`, but we don't want any other parameter. So we might be inclined to make `-Name` and `-Id` optional parameters. But in that case, PowerShell _can't differentiate_ between sets 2-4. It's let us use `-Name` and `-Id` at the same time, since they're both optional. Optional parameters, basically, can't be used to "put yourself" into a parameter set, because PowerShell can't distinguish between "a set where a parameter isn't available" and "a set where a parameter is available, but not used." 
 
@@ -65,21 +65,21 @@ You need to keep typing parameters, then, until there's only one set remaining i
 So, consider this:
 
 ```
-[Parameter(Mandatory, ParameterSetName = "A")]
+[Parameter(Mandatory = $true, ParameterSetName = "A")]
 [switch]
 $All,
 
-[Parameter(Mandatory, ParameterSetName = "B")]
-[Parameter(Mandatory, ParameterSetName = "C")]
-[Parameter(Mandatory, ParameterSetName = "D")]
+[Parameter(Mandatory = $true, ParameterSetName = "B")]
+[Parameter(Mandatory = $true, ParameterSetName = "C")]
+[Parameter(Mandatory = $true, ParameterSetName = "D")]
 [string]
 $CustomerID,
 
-[Parameter(Mandatory, ParameterSetName = "B")]
+[Parameter(Mandatory = $true, ParameterSetName = "B")]
 [string]
 $ID,
 
-[Parameter(Mandatory, ParameterSetName = "C")]
+[Parameter(Mandatory = $true, ParameterSetName = "C")]
 [string]
 $Name
 ```
@@ -93,21 +93,21 @@ Whatever-Command -Name "BLAH"
 Which sets are in consideration? Only "C." It's the only set that contains `-Name`. But we could also add `-CustomerId`, since it "lives" in set "C" also. In fact, we _must_ add `-CustomerId`, because it is _mandatory_ in all sets in which it exists. Now, let's change the definitions a bit:
 
 ```
-[Parameter(Mandatory, ParameterSetName = "A")]
+[Parameter(Mandatory = $true, ParameterSetName = "A")]
 [switch]
 $All,
 
-[Parameter(Mandatory, ParameterSetName = "B")]
-[Parameter(Mandatory, ParameterSetName = "C")]
-[Parameter(Mandatory, ParameterSetName = "D")]
+[Parameter(Mandatory = $true, ParameterSetName = "B")]
+[Parameter(Mandatory = $true, ParameterSetName = "C")]
+[Parameter(Mandatory = $true, ParameterSetName = "D")]
 [string]
 $CustomerID,
 
-[Parameter(ParameterSetName = "B")]
+[Parameter(Mandatory = $false, ParameterSetName = "B")]
 [string]
 $ID,
 
-[Parameter(ParameterSetName = "C")]
+[Parameter(Mandatory = $false, ParameterSetName = "C")]
 [string]
 $Name
 ```

--- a/manuscript/15.md
+++ b/manuscript/15.md
@@ -46,7 +46,7 @@ The fix?
 ```
   rrlog 2 "(L# 102):   RegKey: '$($RegKey)'" > $null
   $theDriverWeWant="some string"
-  Write $theDriverWeWant
+  Write-Output -InputObject $theDriverWeWant
 ```
 
 Forcing the `rrlog` output to the $null variable basically suppresses that output, and switching to `write` from `return` clears up any suggestion that we might not be familiar with PowerShell's under-the-hood ticks.

--- a/manuscript/17.md
+++ b/manuscript/17.md
@@ -3,7 +3,7 @@
 Just start with this code:
 
 ```
-$Userdata = Import-Csv C:\empID.csv
+$Userdata = Import-Csv -Path C:\empID.csv
 ForEach ($User in $Userdata) {
   $User = $User.User 
   $Department = $Department.Department

--- a/manuscript/4.md
+++ b/manuscript/4.md
@@ -46,7 +46,7 @@ PowerShell uses double quotation marks as "magic quotes." In programming languag
 
 ```
 PS C:\> $a = 'Hello'
-PS C:\> $b = "$a, World'
+PS C:\> $b = "$a, World"
 PS C:\> $b
 Hello, World
 ```

--- a/manuscript/5.md
+++ b/manuscript/5.md
@@ -1,6 +1,6 @@
 {sample: true}
 # Problem 5: On Patterns and Suppression
-Consider this code, which doesn't produce the intended output. I'll give you an up-front thing to look for: there's both a technical problem here, as well as some style problems.
+Consider this code, which doesn't produce the intended output. I'll give you an up-front thing to look for: there are technical problems here, as well as some style problems.
 
 ```
 $ErrorActionPreference = 'SilentlyContinue'
@@ -11,7 +11,7 @@ $results = @()
 
 ForEach ($computer in $ComputerName) {
 
-$Results += Get-NetAdapter -CimSession $ComputerName | Select-Object PsComputerName, InterfaceAlias, Status, MacAddress
+    $Results += Get-NetAdapter -CimSession $ComputerName | Select-Object PsComputerName, InterfaceAlias, Status, MacAddress
 
 }
 
@@ -29,13 +29,24 @@ $ErrorActionPreference = 'SilentlyContinue'
 
 Sitting along at the top of a script, this simply disables error reporting, and it's the main reason this script becomes harder to debug. PowerShell _is_ returning a useful error message for the main technical problem in this script, but that message is being ruthlessly suppressed. This is not a good way to gracefully handle errors; a good read of [_The Big Book of PowerShell Error Handling_](https://leanpub.com/thebigbookofpowershellerrorhandling), which is also available in a Spanish translation, concisely outlines the right way to handle anticipated errors without removing useful ones.
 
-Next, let's look at the technical problem:
+Next, let's look at one of the technical problems:
 
 ```
 $Results += Get-NetAdapter -CimSession $ComputerName | Select-Object PsComputerName, InterfaceAlias, Status, MacAddress
 ```
 
 The problem here is that `$ComputerName`, if you follow the logic of the script, contains a computer name. That isn't what `-CimSession` needs, though. Many CIM-based cmdlets don't come with a `-ComputerName` parameter; instead, you're expected to use `New-CimSession` to spin up a new session, and then query against it. This line of code also reveals a major style problem that goes against a core PowerShell coding pattern: accumulating output in an array. [The Big Book of PowerShell Gotchas](https://leanpub.com/thebigbookofpowershellgotchas) outlines why and suggests a more PowerShell-native approach. There are two main reasons: appending to arrays is memory-intensive, as the array has to be recreated each time, and because this approach mis-uses the PowerShell pipeline. It's _very_ common to see people familiar with other programming languages do this, because they're jumping in without really getting what the pipeline is all about. That's fine! It's a learning experience! 
+
+A second major issue with this section is less obvious, but is related to the pipeline problem already mentioned.
+```
+ForEach ($computer in $ComputerName) {
+
+$Results += Get-NetAdapter -CimSession $ComputerName | Select-Object PsComputerName, InterfaceAlias, Status, MacAddress
+
+}
+```
+
+Notice that the ```Get-NetAdapter -CimSession``` is pointing to the _array_ (```$ComputerName```) instead of the individual item from that collection (```$computer```).  While ```Get-NetAdapter``` does accept a collection of items for ```-CimSession```, other cmdlets may only accept a single item.  The ```ForEach``` construct is used to process individual items in the collection for cmdlets that don't accept collections.  
 
 Finally, there's a kinda-technical problem here:
 
@@ -60,12 +71,12 @@ Function Get-NetAdapterInfo {
  ForEach-Object {
   $session = New-CimSession -ComputerName $_
   Get-NetAdapter -CimSession $session | 
-  Select-Object PsComputerName, InterfaceAlias, Status, MacAddress
+  Select-Object -Property PsComputerName, InterfaceAlias, Status, MacAddress
  }
 
 }
 
-Get-NetAdapterInfo -searchbase "ou=whatever,dc=domain,dc=com" | Export-CSV Whatever.csv
+Get-NetAdapterInfo -searchbase "ou=whatever,dc=domain,dc=com" | Export-CSV Whatever.csv -NoTypeInformation
 ```
 
 I've rewritten this as a proper advanced function, which is how pretty much _everything_ in PowerShell should be done. That separates the script's functionality, which is querying network adapter info, from the destination, which in this case is a CSV. By outputting objects, one at a time, to the pipeline, the function becomes self-contained and its output can be sent anywhere. 

--- a/manuscript/6.md
+++ b/manuscript/6.md
@@ -1,25 +1,19 @@
 {sample: true}
 # Problem 6: On Formatting Numbers in Strings
-Here's a snippet of code. This one, I'm not including in the GitHub repo, because there's really only a couple of lines to worry about. For context, here's the large chunk:
+In this example, a process is generating a number of log files and it should stop when it hits the maximum number of files.  This one, I'm not including in the GitHub repo, because there's really only a couple of lines to worry about. For context, here's the large chunk:
 
 ```
-$SourceFile = "C:/Temp/File.txt"
-$DestinationFile = "C:/Temp/NonexistentDirectory/File.txt"
-
-If (Test-Path $DestinationFile) {
+$LogFileDirectory = 'C:\Temp\LogFiles'
+$MaxLogFile = 'Log00010.txt'
 $i = 0
-While (Test-Path $DestinationFile) {
-$i += 1
-$DestinationFile = "C:/Temp/NonexistentDirectory/File$i.txt"
-}
-} Else {
-New-Item -ItemType File -Path $DestinationFile -Force
+while (Test-Path -path "$LogFileDirectory\$MaxLogFile") {
+    $i += 1
+    Add-Content -Path "$LogFileDirectory\Log$i.txt" -Value "Test run $i" -Force
 }
 
-Copy-Item -Path $SourceFile -Destination $DestinationFile -Force
 ```
 
-The _desire_ is for the destination files to be named `File00001.txt` and so on, but obviously as-is it's producing `File1.txt`. Here's the couple of relevant lines:
+The _desire_ is for the destination files to be named `Log00001.txt` and so on, but obviously as-is it's producing `Log1.txt` etc. Here's the couple of relevant lines:
 
 ```
 $i += 1
@@ -48,8 +42,7 @@ In this case, we want to take a number and left-pad it with a certain number of 
 This says I want a 5-digit number, and PowerShell will left-pad with zeroes as needed to hit that quantity.  So:
 
 ```
-$DestinationFile = 
- "C:/Temp/NonexistentDirectory/File{0:d5}.txt" -f $i
+Add-Content -Path ("$LogFileDirectory\Log$i.txt" -f {0:d5}) -Value "Test run $i" -Force
 ```
 
-This would produce filenames like `File00001.txt`, `File00010.txt`, and so on.
+This would produce filenames like `Log00001.txt`, `Log00002.txt`, and so on. 

--- a/manuscript/6.md
+++ b/manuscript/6.md
@@ -8,7 +8,7 @@ $MaxLogFile = 'Log00010.txt'
 $i = 0
 while (Test-Path -path "$LogFileDirectory\$MaxLogFile") {
     $i += 1
-    Add-Content -Path "$LogFileDirectory\Log$i.txt" -Value "Test run $i" -Force
+    Add-Content -Path "$LogFileDirectory\Log$i.txt" -Value "Test run $i"
 }
 
 ```
@@ -17,7 +17,7 @@ The _desire_ is for the destination files to be named `Log00001.txt` and so on, 
 
 ```
 $i += 1
-$DestinationFile = "C:/Temp/NonexistentDirectory/File$i.txt"
+Add-Content -Path "$LogFileDirectory\Log$i.txt" -Value "Test run $i"
 ```
 
 How would you achieve the intended outcome?

--- a/manuscript/9.md
+++ b/manuscript/9.md
@@ -10,13 +10,13 @@ Function Get-ServiceStatus {
   [string[]]$Name
  )
  ForEach ($item in $name) {
-  $svc = Get-Service $item
+  $svc = Get-Service -name $item
   Return $svc.status
  }
 }
 ```
 
-## Spolier!!
+## Spoiler!!
 The `return` keyword is a tricky one in PowerShell. It's especially confusing for programmers from another language, who think they know what it does based on their past experience. Honestly, `return` is something that many on the PowerShell product team regret, for the confusion it's caused. 
 
 In PowerShell v5 classes, `return` does what it should do based on how other languages work: if PowerShell sees you using `return` in a class, it suppresses other things that are output to the pipeline. Instead, it only outputs whatever `return` tells it to, and then it exits the class method. That's how `return` "should" work.
@@ -24,14 +24,17 @@ In PowerShell v5 classes, `return` does what it should do based on how other lan
 But anywhere else in PowerShell, as in the function in this chapter, `return` simply emits one last thing to the pipeline and then exits. Anything you've _previously_ output to the pipeline _still gets output_, which can be confusing. For example:
 
 ```
-Function test {
+Function Start-Test {
  Write "one"
  Return "two"
  Write "three"
  }
+ PS C:\>Start-Test
+ one
+ two
  ```
  
-This will output "one" and "two," but never output "three." That's because `return` is basically a special shortcut to `Write-Output`, one that does indeed output to the pipeline, but that then exits the function. In fact, this `test` example is how _most_ people encounter their first `return` "gotcha," because they won't expect the function to output anything other than just "two."
+This will output "one" and "two," but never output "three." That's because `return` is basically a special shortcut to `Write-Output`, one that does indeed output to the pipeline, but that then exits the function. In fact, this `Start-Test` example is how _most_ people encounter their first `return` "gotcha," because they won't expect the function to output anything other than just "two."
  
 In this chapter, however, we got something a bit different. The function will work _sometimes_. Specifically, it'll work fine when you run it with one service name. But give it two names, and it'll only output the status of the first service, because `return` forces it to exit afterwards. A proper rewrite of this function:
 
@@ -43,8 +46,8 @@ Function Get-ServiceStatus {
   [string[]]$Name
  )
  ForEach ($item in $name) {
-  $svc = Get-Service $item
-  Write-Output $svc.status
+  $svc = Get-Service -name $item
+  Write-Output -InputObject $svc.status
  }
 }
 ```


### PR DESCRIPTION
Hopefully I did this correctly.  This is mostly syntax fixes following best practices from your class (not using aliases, always using the parameter names, etc.)
One thing I did not do was to change all the double quotes to single quotes (as appropriate).  I remember that being one of your best practices because of the "magic quotes" feature.  