### PR TITLE
Fix solution to Problem 1

### DIFF
--- a/manuscript/1.md
+++ b/manuscript/1.md
@@ -3,7 +3,7 @@
 Consider the following code:
 
 ```
-$jsonFiles = Get-ChildItem -path "c:\tmp\json" -filter *.json | 
+$jsonFiles = Get-ChildItem -path "c:\tmp\json" -filter *.json |
   get-content -raw
 $allobjects = $jsonFiles | convertfrom-json
 
@@ -19,7 +19,7 @@ function checkForExistingGroup {
     Process {
             if("gr-$($InputObject.alias)" -in $alreadyCreatedGroup){
                 echo "$($inputobject.alias) exists"
-                } 
+                }
                     else{
                         echo "$($InputObject.alias) does not exist"
                     }
@@ -36,7 +36,7 @@ There are a few problems with the script, and I'll start with the non-substantiv
 
 First, the function is using a name that doesn't meet PowerShell naming conventions.
 
-Second, the function is using `echo`, which is an alias to `Write-Host`; it really should be outputting this "test output" using `Write-Verbose`, which can be disabled when it's no longer needed, and re-enabled when it is, simply by running (or not running) the function using `-Verbose`. 
+Second, the function is using `echo`, which is an alias to `Write-Host`; it really should be outputting this "test output" using `Write-Verbose`, which can be disabled when it's no longer needed, and re-enabled when it is, simply by running (or not running) the function using `-Verbose`.
 
 Substantively, the function itself is using `$alreadyCreatedGroup`, which _exists outside the scope of the function_. This is a very bad coding practice, and can create a variety of difficult-to-debug situations. Except in extremely rare situations, functions should accept input _only_ via parameters.
 
@@ -65,7 +65,7 @@ This is a _very common "gotcha"_ in PowerShell. Whenever you're comparing things
 Revised:
 
 ```
-$alreadyCreatedGroup = Get-UnifiedGroup | select -Expand alias
+$alreadyCreatedGroup = Get-UnifiedGroup | select -ExpandProperty alias
 
 function Test-ForExistingGroup {
     [CmdletBinding()]
@@ -78,11 +78,11 @@ function Test-ForExistingGroup {
     )
 
     Process {
-            if("gr-$($InputObject.alias)" -in $ExistingGroups) {
-                Write-Verbose "$($inputobject.alias) exists"  
-            } else{
-                Write-Verbose "$($InputObject.alias) does not exist"
-            }
+        if ("gr-$InputObject" -in $ExistingGroups) {
+            Write-Verbose "$InputObject exists"
+        } else {
+            Write-Verbose "$InputObject does not exist"
+        }
     }
 }
 
@@ -100,5 +100,3 @@ $alreadyCreatedGroup = Get-UnifiedGroup | select -Expand alias
 ```
 
 The `-ExpandProperty` parameter of `Select-Object` _extracts_ the string from the Alias property, leaving an array of strings rather than a collection of objects.
-
-


### PR DESCRIPTION
Closes https://github.com/concentrateddon/powershell-by-mistake-code/issues/2

Since you `select -Expand alias`, `$InputObject` does not have an alias member. The correct code should be:

```powershell
Process {
    if ("gr-$InputObject" -in $ExistingGroups) {
        Write-Verbose "$InputObject exists"
    } else {
        Write-Verbose "$InputObject does not exist"
    }
}
```